### PR TITLE
Fixed printf bug

### DIFF
--- a/.conky-vision/parse_weather
+++ b/.conky-vision/parse_weather
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+#Avoid errors on printf with systems with a locale that use the comma instead of
+#the dot for floats
+LANG=C
+
 set -eu
 
 forecast=~/".cache/conky-vision/forecast.json"


### PR DESCRIPTION
The parse_weather script would throw an error on printf every time it's called if it's running in a system with a default locale that use comma instead of the dot for floats.
Another suggestion: You could make an HiDPI (4K) version of this theme.