### PR TITLE
Correct min/max temperature parsing

### DIFF
--- a/.conky-vision/parse_weather
+++ b/.conky-vision/parse_weather
@@ -79,6 +79,95 @@ get_avg_property () {
     LC_NUMERIC=C printf %.0f $res
 }
 
+get_min_property () {
+    local res=0
+
+    local prop="$1"
+    local day="$2"
+
+    local idx
+    idx=$(find_position "$day")
+
+    local prop_num=0
+    local time=0
+    local it=0
+
+    local i=0
+
+    local outarray=()
+
+    while true; do
+        [[ $time == "null" ]] && break
+
+        outarray[$i]="$(jq ".list[$idx]$prop" "$forecast")"
+
+        (( i++ ))
+        (( prop_num++ ))
+        (( idx++ ))
+
+        time=$(get_time "$idx")
+
+        # The records for every 3 hours are dumped in an array with no
+        # indication to which day they belong.
+        # The first record of each day (except today) is calculated at time
+        # '00:00:00', so we use that to know when a new day starts.
+        [[ $time == "00:00:00" ]] && break
+    done
+
+    IFS=$'\n'
+    res=($(sort <<<"${outarray[*]}" | head))
+    unset IFS
+
+    [[ $res == "null" ]] && echo $res && return
+
+    LC_NUMERIC=C printf %.0f $res
+}
+
+get_max_property () {
+    local res=0
+
+    local prop="$1"
+    local day="$2"
+
+    local idx
+    idx=$(find_position "$day")
+
+    local prop_num=0
+    local time=0
+    local it=0
+
+    local i=0
+
+    local outarray=()
+
+    while true; do
+        [[ $time == "null" ]] && break
+
+        outarray[$i]="$(jq ".list[$idx]$prop" "$forecast")"
+
+        (( i++ ))
+        (( prop_num++ ))
+        (( idx++ ))
+
+        time=$(get_time "$idx")
+
+        # The records for every 3 hours are dumped in an array with no
+        # indication to which day they belong.
+        # The first record of each day (except today) is calculated at time
+        # '00:00:00', so we use that to know when a new day starts.
+        [[ $time == "00:00:00" ]] && break
+    done
+    IFS=$'\n'
+    res=($(sort -r <<<"${outarray[*]}" | head))
+    echo "$res" '\n' >> ~/foo
+
+    unset IFS
+
+    [[ $res == "null" ]] && echo $res && return
+
+    LC_NUMERIC=C printf %.0f $res
+}
+
 # Certain values cannot be averaged (e.g., the weather description).
 # In that case we just use the value from the first record for that day.
 get_first_property () {
@@ -105,6 +194,10 @@ main () {
 
     if [[ $type == "avg" ]] ; then
         echo "$(get_avg_property "$2" "$3")"
+    elif [[ $type == "min" ]] ; then
+        echo "$(get_min_property "$2" "$3")"
+    elif [[ $type == "max" ]] ; then
+        echo "$(get_max_property "$2" "$3")"
     elif [[ $type == "first" ]] ; then
         echo "$(get_first_property "$2" "$3")"
     fi

--- a/.conkyrc
+++ b/.conkyrc
@@ -132,10 +132,10 @@ ${font}${color}\
 \
 \
 ${font Poiret One:size=12}${color3}\
-${goto 164}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_max' '1'}°\
-${goto 272}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_max' '2'}°\
-${goto 378}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_max' '3'}°\
-${goto 484}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_max' '4'}°\
+${goto 164}${execi 300 ~/.conky-vision/parse_weather 'max' '.main.temp' '1'}°\
+${goto 272}${execi 300 ~/.conky-vision/parse_weather 'max' '.main.temp' '2'}°\
+${goto 378}${execi 300 ~/.conky-vision/parse_weather 'max' '.main.temp' '3'}°\
+${goto 484}${execi 300 ~/.conky-vision/parse_weather 'max' '.main.temp' '4'}°\
 ${font}${color}\
 \
 \
@@ -143,10 +143,10 @@ ${font}${color}\
 \
 ${font Poiret One:size=12}${color4}\
 ${voffset 52}\
-${goto 218}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_min' '1'}°\
-${goto 324}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_min' '2'}°\
-${goto 430}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_min' '3'}°\
-${goto 536}${execi 300 ~/.conky-vision/parse_weather 'avg' '.main.temp_min' '4'}°\
+${goto 218}${execi 300 ~/.conky-vision/parse_weather 'min' '.main.temp' '1'}°\
+${goto 324}${execi 300 ~/.conky-vision/parse_weather 'min' '.main.temp' '2'}°\
+${goto 430}${execi 300 ~/.conky-vision/parse_weather 'min' '.main.temp' '3'}°\
+${goto 536}${execi 300 ~/.conky-vision/parse_weather 'min' '.main.temp' '4'}°\
 ${font}${color}
 \
 \


### PR DESCRIPTION
The previous scheme computed the average over maximum expected
temperatures throughout a day and minimum expected temperatures
throughout a day.
(Essentially, under the previous scheme minimum and maximum temperatures
were daily averages that accounted for uncertainty in the forecast).
Now, minimum temperature is computed as the minimum of
forecast temperatures for a day and the maximum temperature is
computed as the maximum of forecast temperatures for a day.