### PR TITLE
Use gawk to capitalize the day of the week

### DIFF
--- a/.conkyrc
+++ b/.conkyrc
@@ -154,11 +154,11 @@ ${font}${color}
 \
 ${font Poiret One:size=14}${color5}\
 ${voffset 20}\
-${goto 76}${execi 300 LANG=${template9} LC_TIME=${template9} date +%^a}\
-${goto 182}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +1day +%^a}\
-${goto 288}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +2days +%^a}\
-${goto 394}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +3days +%^a}\
-${goto 500}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +4days +%^a}\
+${goto 76}${execi 300 LANG=${template9} LC_TIME=${template9} date +%a | gawk '{print toupper($0);}'}\
+${goto 182}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +1day +%a | gawk '{print toupper($0);}'}\
+${goto 288}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +2days +%a | gawk '{print toupper($0);}'}\
+${goto 394}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +3days +%a | gawk '{print toupper($0);}'}\
+${goto 500}${execi 300 LANG=${template9} LC_TIME=${template9} date -d +4days +%a | gawk '{print toupper($0);}'}\
 ${font}${color}
 \
 \


### PR DESCRIPTION
Use gawk to capitalize the day of the week. If you do use this languages that use special characters on days of the week as Portuguese your text stay wrong.

Example without correction with word Saturday in Portuguese:

Sáb -> SáB

Example with correction with word Saturday in Portuguese:

Sáb -> SÁB